### PR TITLE
use updated syntax for installing homebrew casks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ I've also written a few blog posts that discuss some of the ideas behind Multi:
 The easiest method is to use [Homebrew](https://brew.sh/):
 
 ```
-brew cask install multi
+brew install --cask multi
 ```
 
 Alternatively, you can manually download and run the latest `.dmg` from [Releases](https://github.com/kofigumbs/multi/releases).


### PR DESCRIPTION
As of homebrew 2.6.0, `brew install cask <cask>` has been deprecated in favor of `brew install --cask <cask>`